### PR TITLE
Android: Set "exported" manifest setting to false

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
             android:name=".LocationUpdatesService"
             android:foregroundServiceType="location"
             android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:permission="" />
     </application>
 </manifest>


### PR DESCRIPTION
Sets the Android manifest setting [`android:exported`](https://developer.android.com/guide/topics/manifest/service-element#exported) to `false`. This seems to ensure that only the "parent" app will be able to interact with the background service - and not any other app.

By interpreting the partially Japanese translation of the [original commit](https://github.com/haukepribnow/background_location/commit/b2587729935688f42e016d7337a18e7e3ede8fcd) message, this seems to be a finding of [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF).