### PR TITLE
Android: Fix optional permission result params

### DIFF
--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -218,7 +218,7 @@ class BackgroundLocationService: MethodChannel.MethodCallHandler, PluginRegistry
      * Handle the response from a permission request
      * @return true if the result has been handled.
      */
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
         Log.i(BackgroundLocationPlugin.TAG, "onRequestPermissionResult")
         if (requestCode == REQUEST_PERMISSIONS_REQUEST_CODE) {
             when {

--- a/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
+++ b/android/src/main/kotlin/com/almoullim/background_location/BackgroundLocationService.kt
@@ -218,7 +218,7 @@ class BackgroundLocationService: MethodChannel.MethodCallHandler, PluginRegistry
      * Handle the response from a permission request
      * @return true if the result has been handled.
      */
-    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?): Boolean {
+     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean{
         Log.i(BackgroundLocationPlugin.TAG, "onRequestPermissionResult")
         if (requestCode == REQUEST_PERMISSIONS_REQUEST_CODE) {
             when {


### PR DESCRIPTION
In `BackgroundLocationService.onRequestPermissionsResult`, make the parameters `permissions` and `grantResults` non-nullable.

This is a fix that was applied by multiple people in various forks. I've merged the changes of @hilalbaig ([commit here](https://github.com/hilalbaig/background_location/commit/ec4a769277ef4027ae515262f555a8cea50ff611)) & @deyanm ([commit here](https://github.com/deyanm/background_location/commit/b8cf9406062cfcf1a456cddbddb4a56cca36a9be)) here because their commits were limited to the actual fix. Other forks also changed some seemingly unrelated files - I excluded them here.

This pull request is to track further work on this fix.